### PR TITLE
Add taskwarrior and beancount to nixos and stow

### DIFF
--- a/config/config.sh
+++ b/config/config.sh
@@ -9,3 +9,4 @@ sudo stow --target=/etc networkmanager
 stow --target=$HOME ranger
 stow --target=$HOME mutt
 stow --target=$HOME compton
+stow --target=$HOME taskwarrior

--- a/nixos/apps.nix
+++ b/nixos/apps.nix
@@ -5,5 +5,7 @@
     dropbox
     evince
     pinta
+    beancount
+    fava
   ];
 }

--- a/nixos/cli.nix
+++ b/nixos/cli.nix
@@ -16,6 +16,8 @@
     ffmpegthumbnailer
     atool
     neomutt
+    taskwarrior
+    tasksh
   ];
 
   programs.bash.enableCompletion = true;


### PR DESCRIPTION
the hook for taskwarrior time management is not setup yet because it's a python package, I added it to the todo list